### PR TITLE
Adjustment to support variable height cells

### DIFF
--- a/CollectionViewCenterLayout.swift
+++ b/CollectionViewCenterLayout.swift
@@ -48,8 +48,8 @@ class UICollectionViewCenterLayout: UICollectionViewFlowLayout {
         var currentRowY: CGFloat = -1
 
         for attribute in attributes {
-            if currentRowY != attribute.frame.origin.y {
-                currentRowY = attribute.frame.origin.y
+            if currentRowY != attribute.frame.midY {
+                currentRowY = attribute.frame.midY
                 rows.append(CollectionViewRow(spacing: 10))
             }
             rows.last?.add(attribute: attribute)


### PR DESCRIPTION
Thanks for this layout! It's a great, simple, clean solution.

For collections with cells with variable heights the flow layout aligns cells in a row by center y position, not top y position. This small change works in all cases, whether the cell heights vary or are constant.